### PR TITLE
Fix dot notation issues

### DIFF
--- a/src/MongoDB.Integrations.JsonDotNet.Tests/JsonSerializerAdapterTests.cs
+++ b/src/MongoDB.Integrations.JsonDotNet.Tests/JsonSerializerAdapterTests.cs
@@ -51,14 +51,14 @@ namespace MongoDB.Integrations.JsonDotNet.Tests
         public void TryGetItemSerializationInfo_should_throw_when_contract_has_a_converter()
         {
             var wrappedSerializer = new Newtonsoft.Json.JsonSerializer();
-            var intContract = new Newtonsoft.Json.Serialization.JsonPrimitiveContract(typeof(int))
+            var intContract = new Newtonsoft.Json.Serialization.JsonArrayContract(typeof(int[]))
             {
                 Converter = Substitute.For<Newtonsoft.Json.JsonConverter>()
             };
             wrappedSerializer.ContractResolver = new DictionaryContractResolver(
                 new Dictionary<Type, JsonContract>
                 {
-                    { typeof(int), intContract }
+                    { typeof(int[]), intContract }
                 });
             var subject = new JsonSerializerAdapter<int[]>(wrappedSerializer);
 
@@ -69,14 +69,13 @@ namespace MongoDB.Integrations.JsonDotNet.Tests
         }
 
         [Test]
-        public void TryGetItemSerializationInfo_should_throw_when_contract_is_not_an_array_contract()
+        public void TryGetItemSerializationInfo_should_return_false_when_contract_is_not_an_array_contract()
         {
             var subject = new JsonSerializerAdapter<C>();
 
             BsonSerializationInfo info;
-            Action action = () => subject.TryGetItemSerializationInfo(out info);
-
-            action.ShouldThrow<BsonSerializationException>().And.Message.Should().Contain("is not a JsonArrayContract");
+            var result = subject.TryGetItemSerializationInfo(out info);
+            result.Should().BeFalse();
         }
 
         [Test]

--- a/src/MongoDB.Integrations.JsonDotNet.Tests/JsonSerializerAdapterTests.cs
+++ b/src/MongoDB.Integrations.JsonDotNet.Tests/JsonSerializerAdapterTests.cs
@@ -65,7 +65,7 @@ namespace MongoDB.Integrations.JsonDotNet.Tests
             BsonSerializationInfo info;
             Action action = () => subject.TryGetItemSerializationInfo(out info);
 
-            action.ShouldThrow<BsonSerializationException>().And.Message.Contains("has a Converter");
+            action.ShouldThrow<BsonSerializationException>().And.Message.Should().Contain("has a Converter");
         }
 
         [Test]
@@ -76,7 +76,7 @@ namespace MongoDB.Integrations.JsonDotNet.Tests
             BsonSerializationInfo info;
             Action action = () => subject.TryGetItemSerializationInfo(out info);
 
-            action.ShouldThrow<BsonSerializationException>().And.Message.Contains("is not a JsonArrayContract");
+            action.ShouldThrow<BsonSerializationException>().And.Message.Should().Contain("is not a JsonArrayContract");
         }
 
         [Test]

--- a/src/MongoDB.Integrations.JsonDotNet/JsonSerializerAdapter.cs
+++ b/src/MongoDB.Integrations.JsonDotNet/JsonSerializerAdapter.cs
@@ -79,7 +79,8 @@ namespace MongoDB.Integrations.JsonDotNet
             var arrayContract = contract as JsonArrayContract;
             if (arrayContract == null)
             {
-                throw new BsonSerializationException($"The Json.NET contract for type \"{valueType.Name}\" is not a JsonArrayContract.");
+                serializationInfo = null;
+                return false;
             }
             if (arrayContract.Converter != null)
             {
@@ -111,7 +112,8 @@ namespace MongoDB.Integrations.JsonDotNet
             var objectContract = contract as JsonObjectContract;
             if (objectContract == null)
             {
-                throw new BsonSerializationException($"The Json.NET contract for type \"{valueType.Name}\" is not a JsonObjectContract.");
+                serializationInfo = null;
+                return false;
             }
             if (objectContract.Converter != null)
             {


### PR DESCRIPTION
Fix issue with TryGetMember/ItemSerializationInfo affecting filtering using dot notation.

These should return false if the contract is of the wrong type instead of throwing an Exception.

This is because JsonSerializerAdapter is both an IBsonArraySerializer and an IBsonDocumentSerializer and so either method may be called to test if there's a member of item serializtion info, regardless of the contract type.

This happens in StringFieldDefinitionHelper.Resolve when resolving a field using dot notation.